### PR TITLE
Additional features to mapper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kim-seng-chiu/jsonderulo",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kim-seng-chiu/jsonderulo",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "lodash.get": "^4.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kim-seng-chiu/jsonderulo",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kim-seng-chiu/jsonderulo",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "lodash.get": "^4.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kim-seng-chiu/jsonderulo",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Tries to return whatever you pass it as a JSON object",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kim-seng-chiu/jsonderulo",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Tries to return whatever you pass it as a JSON object",
   "main": "index.js",
   "scripts": {

--- a/src/mapper.js
+++ b/src/mapper.js
@@ -5,13 +5,25 @@ function mapper(input, schema) {
   Object.keys(schema).forEach((schemaKey) => {
     const dataType = schema[schemaKey].type;
     const mapItems = schema[schemaKey].mapItems;
+    const defaultValue = schema[schemaKey].defaultValue ?? null;
     switch (dataType) {
       case "string":
       case "number":
       case "boolean":
       case "array":
+        if(schema[schemaKey].staticValue) {
+          mappedObject[schemaKey] = schema[schemaKey].staticValue;
+          return;
+        }
         const resolvedPath = mapItems.find(mapItem => get(input, mapItem) !== undefined)
-        mappedObject[schemaKey] = resolvedPath ? get(input, resolvedPath) : null;
+        let resolvedValued = resolvedPath ? get(input, resolvedPath) : defaultValue;
+        if(schema[schemaKey].mappingValueRules) {
+          const validMapRule = schema[schemaKey].mappingValueRules.find(rule => rule.original.includes(resolvedValued));
+          if(validMapRule) {
+            resolvedValue = validMapRule.target;
+          }
+        }
+        mappedObject[schemaKey] = resolvedValue;
         return;
       case "object":
         mappedObject[schemaKey] = mapper(


### PR DESCRIPTION
* Static value property can now be read as the overriding value for a property.
* Mapping Value Rules (early version) is to allow users to map from one value to another. Whether changing case (snake to Pascal) or data type, the rules should be able to map from an `original` to a `target`.

PR to create a trail of changes.