### PR TITLE
refactor: TS-271 Add support for "tag" and "set" type

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Tries to return whatever you pass it as a JSON object",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest --passWithNoTests",
+    "test:watch": "npm test -- --watch"
   },
   "repository": {
     "type": "git",

--- a/src/mapper.js
+++ b/src/mapper.js
@@ -1,39 +1,92 @@
+/** @format */
+
 const get = require("lodash.get");
 
-function mapper(input, schema) {
+const getMapItem = (input, mapItems) => {
+  let value;
+  if (Array.isArray(mapItems)) {
+    mapItems.forEach((item) => {
+      value = get(input, item);
+      if (value !== undefined) {
+        //return the value for the first mapped item found
+        return value;
+      }
+    });
+  }
+  return value;
+};
+
+const getSet = (inputValue, schemaValue) => {
+  let resolvedValue = {};
+  let result = {};
+  for (const ruleKey in schemaValue.properties) {
+    const ruleValue = schemaValue.properties[ruleKey];
+    resolvedValue = getMapItem(inputValue, ruleValue.mapItems);
+    if (typeof resolvedValue === "object") {
+      if (typeof ruleValue.properties === "object") {
+        result[ruleKey] = getSet(resolvedValue, ruleValue);
+      }
+    } else {
+      if (resolvedValue) {
+        result[ruleKey] = resolvedValue;
+      }
+    }
+  }
+  return result;
+};
+
+const mapper = (input, schema) => {
   const mappedObject = {};
   Object.keys(schema).forEach((schemaKey) => {
-    const dataType = schema[schemaKey].type;
-    const mapItems = schema[schemaKey].mapItems;
-    const defaultValue = schema[schemaKey].defaultValue ?? null;
+    const schemaValue = schema[schemaKey];
+    const dataType = schemaValue.type;
+    const mapItems = schemaValue.mapItems;
+    const defaultValue = schemaValue.defaultValue ?? null;
+
     switch (dataType) {
       case "string":
       case "number":
       case "boolean":
       case "array":
-        if(schema[schemaKey].staticValue) {
-          mappedObject[schemaKey] = schema[schemaKey].staticValue;
+        if (schemaValue.staticValue) {
+          mappedObject[schemaKey] = schemaValue.staticValue;
           return;
         }
-        const resolvedPath = mapItems ? mapItems.find(mapItem => get(input, mapItem) !== undefined) : false;
-        let resolvedValue = resolvedPath ? get(input, resolvedPath) : defaultValue;
-        if(schema[schemaKey].mappingValueRules) {
-          const validMapRule = schema[schemaKey].mappingValueRules.find(rule => rule.original.includes(resolvedValue));
-          if(validMapRule) {
+        const resolvedPath = mapItems
+          ? mapItems.find((mapItem) => get(input, mapItem) !== undefined)
+          : false;
+        let resolvedValue = resolvedPath
+          ? get(input, resolvedPath)
+          : defaultValue;
+        if (schemaValue.mappingValueRules) {
+          const validMapRule = schema[
+            schemaKey
+          ].mappingValueRules.find((rule) =>
+            rule.original.includes(resolvedValue)
+          );
+          if (validMapRule) {
             resolvedValue = validMapRule.target;
           }
         }
         mappedObject[schemaKey] = resolvedValue;
         return;
       case "object":
-        mappedObject[schemaKey] = mapper(
-          input,
-          schema[schemaKey].properties
-        );
+        mappedObject[schemaKey] = mapper(input, schemaValue.properties);
         return;
-      // case "array(objects)":
+      case "set":
+        if (schemaValue.mapItems) {
+          let inputValues = getMapItem(input, schemaValue.mapItems);
+          let resolvedValues = [];
+          inputValues.forEach((inputValue) => {
+            resolvedValues.push(getSet(inputValue, schemaValue));
+          });
+          mappedObject[schemaKey] = resolvedValues;
+        }
+
+        return;
     }
   });
   return mappedObject;
-}
+};
+
 module.exports = mapper;

--- a/src/mapper.js
+++ b/src/mapper.js
@@ -39,13 +39,18 @@ const getSetItem = (inputValue, schemaValue) => {
       if (mapSet) {
         result[ruleKey] = mapSet;
       }
-      return result;
-    }
-    resolvedValue = getMapItem(inputValue, ruleValue.mapItems);
-    if (typeof resolvedValue === "object" && ruleValue.properties) {
-      result[ruleKey] = getSetItem(resolvedValue, ruleValue);
-    } else if (resolvedValue) {
-      result[ruleKey] = resolvedValue;
+    } else {
+      resolvedValue = getMapItem(inputValue, ruleValue.mapItems);
+      if (typeof resolvedValue === "object" && ruleValue.properties) {
+        result[ruleKey] = getSetItem(resolvedValue, ruleValue);
+      } else {
+        if (!resolvedValue) {
+          resolvedValue = ruleValue.defaultValue;
+        }
+        if (resolvedValue) {
+          result[ruleKey] = resolvedValue;
+        }
+      }
     }
   }
   return result;

--- a/src/mapper.js
+++ b/src/mapper.js
@@ -75,20 +75,20 @@ const mapper = (input, schema) => {
       hasMapItems = typeof mapItems !== "undefined";
     }
 
-    if (dataType === "set" && hasMapItems) {
-      resolvedValue = getSet(mapItems, value.properties);
-    } else if (dataType === "tag" && hasMapItems) {
-      resolvedValue = getTag(mapItems);
-    } else {
-      if (value.properties) {
-        resolvedValue = hasMapItems
-          ? mapper(mapItems, value.properties)
-          : mapper(input, value.properties);
+    if (hasMapItems) {
+      if (dataType === "set") {
+        resolvedValue = getSet(mapItems, value.properties);
+      } else if (dataType === "tag") {
+        resolvedValue = getTag(mapItems);
       } else {
-        resolvedValue = hasMapItems
-          ? mapValueRules(value.mappingValueRules, mapItems)
-          : value.defaultValue;
+        resolvedValue = value.properties
+          ? mapper(mapItems, value.properties)
+          : mapValueRules(value.mappingValueRules, mapItems);
       }
+    } else {
+      resolvedValue = value.properties
+        ? mapper(input, value.properties)
+        : value.defaultValue;
     }
 
     if (typeof resolvedValue !== "undefined") {

--- a/src/mapper.js
+++ b/src/mapper.js
@@ -51,10 +51,10 @@ const getResolvedValue = (input, properties, schemaValue) => {
     if (typeof resolvedValue === "object" && properties.properties) {
       return getSetItem(resolvedValue, properties);
     } else {
-      if (!resolvedValue) {
+      if (typeof resolvedValue === "undefined") {
         resolvedValue = properties.defaultValue;
       }
-      if (resolvedValue) {
+      if (typeof resolvedValue !== "undefined") {
         resolvedValue = mapValueRules(schemaValue, resolvedValue);
         return resolvedValue;
       }
@@ -67,7 +67,7 @@ const getSetItem = (input, schemaValue) => {
   for (const key in schemaValue.properties) {
     const properties = schemaValue.properties[key];
     const resolvedValue = getResolvedValue(input, properties, schemaValue);
-    if (resolvedValue) {
+    if (typeof resolvedValue !== "undefined") {
       result[key] = resolvedValue;
     }
   }

--- a/src/mapper.js
+++ b/src/mapper.js
@@ -46,6 +46,8 @@ const getResolvedValue = (input, properties, schemaValue) => {
     return properties.staticValue;
   } else if (properties.type === "set") {
     return getSet(input, properties);
+  } else if (properties.type === "tag") {
+    return getTag(input, properties);
   } else {
     let resolvedValue = getMapItem(input, properties.mapItems);
     if (typeof resolvedValue === "object" && properties.properties) {
@@ -72,6 +74,18 @@ const getSetItem = (input, schemaValue) => {
     }
   }
   return result;
+};
+
+const getTag = (input, schemaValue) => {
+  const result = [];
+  let resolvedValue = getMapItem(input, schemaValue.mapItems);
+  for (const Key in resolvedValue) {
+    const Value = resolvedValue[Key];
+    result.push({ Key, Value });
+  }
+  if (result.length) {
+    return result;
+  }
 };
 
 const mapper = (input, schema) => {

--- a/test/src/mapper.test.js
+++ b/test/src/mapper.test.js
@@ -60,9 +60,7 @@ describe("mapper", () => {
       };
 
       const result = mapper(input, template);
-      const expected = {
-        provider: "aws",
-      };
+      const expected = { configuration: null, provider: "aws" };
       expect(result).toStrictEqual(expected);
     });
   });

--- a/test/src/mapper.test.js
+++ b/test/src/mapper.test.js
@@ -45,4 +45,109 @@ describe("mapper", () => {
       });
     });
   });
+
+  describe("GIVEN an object of arrays", () => {
+    const template = {
+      configuration: {
+        type: "object",
+        properties: {
+          LifecycleConfiguration: {
+            type: "object",
+            properties: {
+              Rules: {
+                type: "set",
+                mapItems: ["configuration.lifecycle_rule"],
+                properties: {
+                  AbortIncompleteMultipartUpload: {
+                    type: "object",
+                    mapItems: ["abort_incomplete_multipart_upload[0]"],
+                    properties: {
+                      DaysAfterInitiation: {
+                        type: "number",
+                        mapItems: ["days_after_initiation"],
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    describe("AND one lifecycle_rule as input", () => {
+      it("SHOULD add it to Rules", () => {
+        const input = {
+          configuration: {
+            lifecycle_rule: [
+              {
+                abort_incomplete_multipart_upload: [
+                  {
+                    days_after_initiation: 2,
+                  },
+                ],
+              },
+            ],
+          },
+        };
+
+        const result = mapper(input, template);
+        const expected = {
+          Rules: [
+            {
+              AbortIncompleteMultipartUpload: {
+                DaysAfterInitiation: 2,
+              },
+            },
+          ],
+        };
+        expect(result.configuration.LifecycleConfiguration).toStrictEqual(
+          expected
+        );
+      });
+      describe("AND more than one lifecycle_rule as input", () => {
+        it("SHOULD add each to Rules", () => {
+          const input = {
+            configuration: {
+              lifecycle_rule: [
+                {
+                  abort_incomplete_multipart_upload: [
+                    {
+                      days_after_initiation: 30,
+                    },
+                  ],
+                },
+                {
+                  abort_incomplete_multipart_upload: [
+                    {
+                      days_after_initiation: 2,
+                    },
+                  ],
+                },
+              ],
+            },
+          };
+
+          const result = mapper(input, template);
+          const expected = {
+            Rules: [
+              {
+                AbortIncompleteMultipartUpload: {
+                  DaysAfterInitiation: 30,
+                },
+              },
+              {
+                AbortIncompleteMultipartUpload: {
+                  DaysAfterInitiation: 2,
+                },
+              },
+            ],
+          };
+          expect(result.configuration.LifecycleConfiguration).toStrictEqual(
+            expected
+          );
+        });
+      });
+    });
+  });
 });

--- a/test/src/mapper.test.js
+++ b/test/src/mapper.test.js
@@ -68,6 +68,11 @@ describe("mapper", () => {
                       },
                     },
                   },
+                  Status: {
+                    type: "string",
+                    mapItems: ["status"],
+                    defaultValue: "Disabled",
+                  },
                   Transitions: {
                     type: "set",
                     mapItems: ["transition"],
@@ -125,6 +130,7 @@ describe("mapper", () => {
               AbortIncompleteMultipartUpload: {
                 DaysAfterInitiation: 2,
               },
+              Status: "Disabled",
             },
           ],
         };
@@ -144,6 +150,7 @@ describe("mapper", () => {
                     days_after_initiation: 30,
                   },
                 ],
+                Status: "Disabled",
               },
               {
                 abort_incomplete_multipart_upload: [
@@ -151,6 +158,7 @@ describe("mapper", () => {
                     days_after_initiation: 2,
                   },
                 ],
+                Status: "Disabled",
               },
             ],
           },
@@ -163,11 +171,13 @@ describe("mapper", () => {
               AbortIncompleteMultipartUpload: {
                 DaysAfterInitiation: 30,
               },
+              Status: "Disabled",
             },
             {
               AbortIncompleteMultipartUpload: {
                 DaysAfterInitiation: 2,
               },
+              Status: "Disabled",
             },
           ],
         };
@@ -202,6 +212,7 @@ describe("mapper", () => {
         const expected = {
           Rules: [
             {
+              Status: "Disabled",
               Transitions: [
                 {
                   StorageClass: "GLACIER",
@@ -212,6 +223,57 @@ describe("mapper", () => {
                   TransitionInDays: 30,
                 },
               ],
+            },
+          ],
+        };
+        expect(result.configuration.LifecycleConfiguration).toStrictEqual(
+          expected
+        );
+      });
+    });
+    describe("AND input is empty and is mapped to a default value", () => {
+      it("SHOULD set the input with the default value", () => {
+        const input = {
+          configuration: {
+            lifecycle_rule: [
+              {
+                id: "GlacierRule",
+                status: "Enabled",
+              },
+            ],
+          },
+        };
+
+        const result = mapper(input, template);
+        const expected = {
+          Rules: [
+            {
+              Status: "Enabled",
+            },
+          ],
+        };
+        expect(result.configuration.LifecycleConfiguration).toStrictEqual(
+          expected
+        );
+      });
+    });
+    describe("AND input is empty and is mapped to a default value", () => {
+      it("SHOULD set the input with the default value", () => {
+        const input = {
+          configuration: {
+            lifecycle_rule: [
+              {
+                id: "GlacierRule",
+              },
+            ],
+          },
+        };
+
+        const result = mapper(input, template);
+        const expected = {
+          Rules: [
+            {
+              Status: "Disabled",
             },
           ],
         };

--- a/test/src/mapper.test.js
+++ b/test/src/mapper.test.js
@@ -1,6 +1,8 @@
+/** @format */
+
 const mapper = require("../../src/mapper");
 const { input1, input2, input3 } = require("../mocks/mapper/data.mock");
-const {bookTemplate} = require("../mocks/mapper/template.mock");
+const { bookTemplate } = require("../mocks/mapper/template.mock");
 describe("mapper", () => {
   describe("When given an input object and a template to match", () => {
     it("Should map the input object the new template keys and return it as an object", () => {
@@ -8,7 +10,7 @@ describe("mapper", () => {
         OverallRating: null,
         AdditionalInfo: { Genre: null, Publisher: null },
         Title: "Catcher in the Rye",
-        Author: { Name: "J.D. Salinger", Origin: null },
+        Author: { Name: "J.D. Salinger", Origin: "USA" },
         YearPublished: "1951",
         IsFiction: true,
         NumberOfPages: 234,

--- a/test/src/mapper.test.js
+++ b/test/src/mapper.test.js
@@ -7,8 +7,6 @@ describe("mapper", () => {
   describe("When given an input object and a template to match", () => {
     it("Should map the input object the new template keys and return it as an object", () => {
       expect(mapper(input1, bookTemplate)).toMatchObject({
-        OverallRating: null,
-        AdditionalInfo: { Genre: null, Publisher: null },
         Title: "Catcher in the Rye",
         Author: { Name: "J.D. Salinger", Origin: "USA" },
         YearPublished: "1951",
@@ -18,11 +16,6 @@ describe("mapper", () => {
     });
     it("Should map the input object to new template keys with the desired data structure", () => {
       expect(mapper(input2, bookTemplate)).toMatchObject({
-        OverallRating: null,
-        AdditionalInfo: {
-          Genre: null,
-          Publisher: null,
-        },
         Title: "Nineteen Eighty-Four",
         Author: { Name: "George Orwell", Origin: "England" },
         YearPublished: "1949",
@@ -60,7 +53,7 @@ describe("mapper", () => {
       };
 
       const result = mapper(input, template);
-      const expected = { configuration: null, provider: "aws" };
+      const expected = { provider: "aws" };
       expect(result).toStrictEqual(expected);
     });
   });

--- a/test/src/mapper.test.js
+++ b/test/src/mapper.test.js
@@ -46,6 +46,70 @@ describe("mapper", () => {
     });
   });
 
+  describe("GIVEN key is mapped to a static value", () => {
+    it("SHOULD add the key to the output, even if it is not in the input", () => {
+      const template = {
+        provider: {
+          type: "string",
+          staticValue: "aws",
+        },
+        configuration: {},
+      };
+      const input = {
+        configuration: {},
+      };
+
+      const result = mapper(input, template);
+      const expected = {
+        provider: "aws",
+      };
+      expect(result).toStrictEqual(expected);
+    });
+  });
+
+  describe("GIVEN mappingValueRules is configured", () => {
+    it("SHOULD replace mappingValueRules.original with .target in the input", () => {
+      const template = {
+        configuration: {
+          type: "object",
+          properties: {
+            ObjectLockConfiguration: {
+              type: "object",
+              properties: {
+                ObjectLockEnabled: {
+                  type: "boolean",
+                  defaultValue: "Disabled",
+                  description: "",
+                  mapItems: [
+                    "configuration.object_lock_enabled",
+                    "configuration.object_lock_configuration[0].object_lock_enabled",
+                  ],
+                  mappingValueRules: [
+                    {
+                      original: ["Enabled", "true", true],
+                      target: "Enabled",
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const input = {
+        configuration: { object_lock_enabled: true },
+      };
+
+      const result = mapper(input, template);
+      const expected = {
+        ObjectLockEnabled: "Enabled",
+      };
+      expect(result.configuration.ObjectLockConfiguration).toStrictEqual(
+        expected
+      );
+    });
+  });
   describe("GIVEN a schema of type 'set'", () => {
     const template = {
       configuration: {
@@ -231,8 +295,8 @@ describe("mapper", () => {
         );
       });
     });
-    describe("AND input is empty and is mapped to a default value", () => {
-      it("SHOULD set the input with the default value", () => {
+    describe("AND input is populated and is mapped to a default value", () => {
+      it("SHOULD set the input with the populated value", () => {
         const input = {
           configuration: {
             lifecycle_rule: [


### PR DESCRIPTION
### Issue Link:

[RULE-2211](https://cloudconformity.atlassian.net/browse/TS-271)

### What does it do?

Refactor mapper to add support for "tag" and "set" type. This in turn is to support transforming a terraform S3 Bucket - LifecycleConfiguration to Cloudformation. 

This config contains types which are an array of objects ( set ) and may contain tags e.g
```
       
        lifecycle_rule {
          id      = "GlacierRule"
          filter {
            tags = {
              rule      = "log"
              autoclean = "true"
            }
          }
      
        }

```
should be transformed to 
```
{
        Rules: [
          {
            Id: "GlacierRule",
            TagFilters: [
              {
                Key: "autoclean",
                Value: true,
              },
              {
                Key: "rule",
                Value: "log",
              },
            ],
          },
        ],
      }
```
#### Checklist

- [x] I will squash before merging

---

#### Related PR's

