### PR TITLE
new data type mapping with unit test and updated documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,25 @@ The main function `mapper` takes two arguments, currently.
 
 | attribute | data type | required | values |
 | --------- | --------- | -------- | ------ |
-| type | string | yes | "string", "number", "boolean", "datetime", "object", "array" |
+| type | string | yes | "string", "number", "boolean", "datetime", "object", "array", "set", "tags", "set(strings)" |
 | mapItems | array(strings) | no | - |
 | description | string | no | - |
 | properties | object | yes for data type object | - |
+
+### Data types for `mapper`
+(documentation WIP)
+| data type | description of usage |
+| --------- | -------------------- |
+| string | |
+| number | |
+| boolean | |
+| datetime | |
+| object | |
+| array | |
+| set | |
+| tags | |
+| set(strings) | |
+
+### Roadmap for `mapper`
+* Refactor for consistent variable names
+* `getPrimitivesSet` to be used for set(strings | numbers)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.4.0",
       "license": "MIT",
       "dependencies": {
+        "is-primitive": "^3.0.1",
         "lodash.get": "^4.4.2",
         "prettier": "^2.2.1"
       },
@@ -991,9 +992,9 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -2802,6 +2803,14 @@
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true
     },
+    "node_modules/is-primitive": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-3.0.1.tgz",
+      "integrity": "sha512-GljRxhWvlCNRfZyORiH77FwdFwGcMO620o37EOYC0ORWdq+WYNVqW0w2Juzew4M+L81l6/QS3t5gkkihyRqv9w==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -3701,9 +3710,9 @@
       "dev": true
     },
     "node_modules/json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "dev": true
     },
     "node_modules/json-schema-traverse": {
@@ -3734,18 +3743,18 @@
       }
     },
     "node_modules/jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "dev": true,
-      "engines": [
-        "node >=0.6.0"
-      ],
       "dependencies": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
+        "json-schema": "0.4.0",
         "verror": "1.10.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
       }
     },
     "node_modules/kind-of": {
@@ -3936,9 +3945,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "node_modules/mixin-deep": {
@@ -4352,9 +4361,9 @@
       }
     },
     "node_modules/path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "node_modules/performance-now": {
@@ -5512,9 +5521,9 @@
       "dev": true
     },
     "node_modules/tmpl": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
     },
     "node_modules/to-fast-properties": {
@@ -5942,9 +5951,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.5.tgz",
-      "integrity": "sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==",
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.8.tgz",
+      "integrity": "sha512-ri1Id1WinAX5Jqn9HejiGb8crfRio0Qgu8+MtL36rlTA6RLsMdWt1Az/19A2Qij6uSHUMphEFaTKa4WG+UNHNw==",
       "dev": true,
       "engines": {
         "node": ">=8.3.0"
@@ -6860,9 +6869,9 @@
       }
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
     },
     "ansi-styles": {
@@ -8279,6 +8288,11 @@
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true
     },
+    "is-primitive": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-3.0.1.tgz",
+      "integrity": "sha512-GljRxhWvlCNRfZyORiH77FwdFwGcMO620o37EOYC0ORWdq+WYNVqW0w2Juzew4M+L81l6/QS3t5gkkihyRqv9w=="
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -8981,9 +8995,9 @@
       "dev": true
     },
     "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "dev": true
     },
     "json-schema-traverse": {
@@ -9008,14 +9022,14 @@
       }
     },
     "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
+        "json-schema": "0.4.0",
         "verror": "1.10.0"
       }
     },
@@ -9162,9 +9176,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "mixin-deep": {
@@ -9487,9 +9501,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "performance-now": {
@@ -10414,9 +10428,9 @@
       "dev": true
     },
     "tmpl": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
     },
     "to-fast-properties": {
@@ -10767,9 +10781,9 @@
       }
     },
     "ws": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.5.tgz",
-      "integrity": "sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==",
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.8.tgz",
+      "integrity": "sha512-ri1Id1WinAX5Jqn9HejiGb8crfRio0Qgu8+MtL36rlTA6RLsMdWt1Az/19A2Qij6uSHUMphEFaTKa4WG+UNHNw==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://github.com/kim-seng-chiu/jsonDerulo#readme",
   "dependencies": {
+    "is-primitive": "^3.0.1",
     "lodash.get": "^4.4.2",
     "prettier": "^2.2.1"
   },

--- a/src/mapper.js
+++ b/src/mapper.js
@@ -1,6 +1,7 @@
 /** @format */
 
 const get = require("lodash.get");
+const isPrimitive = require("is-primitive");
 
 const mapValueRules = (mappingValueRules, originalValue) => {
   let newValue = originalValue;
@@ -68,7 +69,7 @@ const getPrimitivesSet = (sourceValues, paths) => {
               break;
             }
           } else {
-            if(typeof sourceValue !== "object") {
+            if(!isPrimitive(sourceValue)) {
               // assume if source is array or object, it requires remapping
               // please raise a bug if this is not the case
               resolvedValues.push(sourceValue)

--- a/src/mapper.js
+++ b/src/mapper.js
@@ -56,6 +56,31 @@ const getSet = (mapItems, properties) => {
   }
 };
 
+const getPrimitivesSet = (sourceValues, paths) => {
+  if(Array.isArray(paths)) {
+    let resolvedValues = [];
+    if(Array.isArray(sourceValues)) {
+      sourceValues.forEach(sourceValue => {
+        for (const item in paths) {
+          if(paths[item]) {
+            if(get(sourceValue, paths[item])) {
+              resolvedValues.push(get(sourceValue, paths[item]));
+              break;
+            }
+          } else {
+            if(typeof sourceValue !== "object") {
+              // assume if source is array or object, it requires remapping
+              // please raise a bug if this is not the case
+              resolvedValues.push(sourceValue)
+            }
+          }
+        }
+      });
+      return resolvedValues;
+    }
+  }
+}
+
 const mapper = (input, schema) => {
   const mappedObject = {};
   for (const key in schema) {
@@ -80,6 +105,8 @@ const mapper = (input, schema) => {
         resolvedValue = getSet(mapItems, value.properties);
       } else if (dataType === "tag") {
         resolvedValue = getTag(mapItems);
+      } else if (dataType === "set(strings)") {
+        resolvedValue = getPrimitivesSet(mapItems, value.properties.mapItems);
       } else {
         resolvedValue = value.properties
           ? mapper(mapItems, value.properties)

--- a/test/src/mapper.test.js
+++ b/test/src/mapper.test.js
@@ -338,4 +338,62 @@ describe("mapper", () => {
       });
     });
   });
+  describe("GIVEN set(strings) has been configured", () => {
+    const schemaSetStrings = {
+      configuration: {
+        type: "object",
+        properties: {
+          Name: {
+            type: "string",
+            mapItems: ["configuration.name"],
+          },
+          Subnets: {
+            type: "set(strings)",
+            mapItems: ["configuration.subnets"],
+            properties: {
+              mapItems: ["reference", ""],
+            },
+          },
+        },
+      },
+    };
+    describe("WHEN an array of objects is provided as input", () => {
+      const testData1 = {
+        configuration: {
+          name: "Test1",
+          subnets: [
+            {
+              reference: "aws_subnet.example1",
+              aws_subnet: [],
+            },
+            {
+              reference: "aws_subnet.example2",
+              aws_subnet: [],
+            },
+          ],
+        },
+      };
+      it("SHOULD map a single value from each object", () => {
+        expect(mapper(testData1, schemaSetStrings)).toMatchObject({
+          configuration: {
+            Name: "Test1",
+            Subnets: ["aws_subnet.example1", "aws_subnet.example2"],
+          },
+        });
+      });
+    });
+    describe("WHEN an array of strings is provided as input", () => {
+      const testData2 = {
+        configuration: {
+          name: "Test2",
+          subnets: ["198.0.1.15/1", "20.0.1.23/1"],
+        },
+      };
+      it("SHOULD return the array of strings", () => {
+        expect(mapper(testData2, schemaSetStrings)).toMatchObject({                                                                                                                                 
+          configuration: { Name: 'Test2', Subnets: [ '198.0.1.15/1', '20.0.1.23/1' ] }
+        });
+      })
+    })
+  });
 });


### PR DESCRIPTION
* mapping an array of data types (primitives or objects) to an array of primitives.
  * Getting a list of names: [{id: 1, name: "Orange"}, {id: 2, name: "Apple"} > ["Orange", "Apple"]
* documentation in the process of getting updates, now just including new data types, mapper accepts
* unit tests for new mapping