### PR TITLE
fix: TS-613 fix mapping bug

### DIFF
--- a/src/mapper.js
+++ b/src/mapper.js
@@ -200,7 +200,7 @@ function Mapper(options) {
               break;
           }
         } else {
-          resolvedValue = value.properties
+          resolvedValue = value.properties && value.type === "object"
             ? this.map(input, value.properties)
             : value.defaultValue;
         }


### PR DESCRIPTION
Fix bug of mapping logic:

Before:
When `mapItems` can't be found,  and `value.properties` is defined, mapper will go thought all the children properties recursively.
This will cause bug when I have a `"set"` property, and its children properties include `staticValue` property. 
I expect an `undefined` value for the `mapItems` can't be found. But, the `staticValue` property will be generated as they will outcome define value and return an object with these properties.

i.e.
```
Arrays: {
type: "set",
mapItems: ["configuration.references.array"],
properties: {
  "A": {
     type: "string",
     mapItems: ["A"]
  },
  "SVal": {
    type: "string",
    staticValue: "hello"
  }
}
```
when references.array can't be found, expect `Array: undefined`, but get `Array: { SVal: "hello" }`

Now:
Add a restriction for processing the non-found `mapItems`. Only go though the children properties when the type is `"object"`. This can protect the `"set"` property.